### PR TITLE
chore(ci): set up dependabot for dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "docusaurus"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "docusaurus"


### PR DESCRIPTION
This PR sets up **Dependabot** for automated dependency management across the repository.  
It introduces a configuration file (`.github/dependabot.yaml`) specifying weekly checks for:

- `npm` packages in the root directory
- `github-actions` workflows

Updates will target the branches and ensure that dependencies remain secure and up-to-date with minimal manual intervention.
