### PR TITLE
ci(dependabot): configure automated updates for default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR introduces a split configuration approach for **Dependabot** updates:

- A configuration in the default branch **without `target-branch`** to allow GitHub to use its built-in default branch resolution.  
- A separate configuration in another branch that **explicitly sets `target-branch`** pointing to the default branch.

This setup ensures:
- Smooth onboarding for branches that don’t yet have a `.github/dependabot.yaml` file.
- Consistent updates targeting the default branch regardless of the source branch.
- Flexibility to maintain per-branch configurations in the future if needed.

The goal is to simplify dependency management while maintaining clarity and control over update targets across branches.